### PR TITLE
Add validity check to prevmonth and nextmonth functions

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -132,6 +132,8 @@ def monthlen(year, month):
 
 
 def prevmonth(year, month):
+    if not 1 <= month <= 12:
+        raise IllegalMonthError(month)
     if month == 1:
         return year-1, 12
     else:
@@ -139,6 +141,8 @@ def prevmonth(year, month):
 
 
 def nextmonth(year, month):
+    if not 1 <= month <= 12:
+        raise IllegalMonthError(month)
     if month == 12:
         return year+1, 1
     else:


### PR DESCRIPTION
`calendar.nextmonth(2018, 6)` returns `(2018, 7)` but not checking if the month is valid. It should raise an `IllegalMonthError` if the month is not valid. Similarly, `calendar.prevmonth` should check it too.
